### PR TITLE
Update EnvironmentManager.php

### DIFF
--- a/src/Helpers/EnvironmentManager.php
+++ b/src/Helpers/EnvironmentManager.php
@@ -4,6 +4,7 @@ namespace RachidLaasri\LaravelInstaller\Helpers;
 
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 
 class EnvironmentManager
 {
@@ -96,7 +97,7 @@ class EnvironmentManager
         $envFileData =
         'APP_NAME=\''.$request->app_name."'\n".
         'APP_ENV='.$request->environment."\n".
-        'APP_KEY='.'base64:'.base64_encode(str_random(32))."\n".
+        'APP_KEY='.'base64:'.base64_encode(Str::random(32))."\n".
         'APP_DEBUG='.$request->app_debug."\n".
         'APP_LOG_LEVEL='.$request->app_log_level."\n".
         'APP_URL='.$request->app_url."\n\n".


### PR DESCRIPTION
As for Laravel 6.0, all str_ helpers have been removed (they now reside in a separate package), the Str:: class should be used instead: https://laravel.com/docs/6.x/upgrade#helpers