### PR TITLE
Clear DB Manager cached config values from the .env file

### DIFF
--- a/src/Controllers/EnvironmentController.php
+++ b/src/Controllers/EnvironmentController.php
@@ -139,6 +139,9 @@ class EnvironmentController extends Controller
                 ],
             ],
         ]);
+        
+        // Purge any cached config values at run-time by the DatabaseManager instance
+        DB::purge();
 
         try {
             DB::connection()->getPdo();

--- a/src/Controllers/EnvironmentController.php
+++ b/src/Controllers/EnvironmentController.php
@@ -139,8 +139,7 @@ class EnvironmentController extends Controller
                 ],
             ],
         ]);
-        
-        // Purge any cached config values at run-time by the DatabaseManager instance
+
         DB::purge();
 
         try {


### PR DESCRIPTION
We should purge the connection config values before checking whether the SQL credentials inserted by the user are valid or not.

The DatabaseManager class caches the values at run-time from the auto-generated .env when installing/creating a laravel project. This makes changing the config values on the fly redundant without purging the values first.

Tested on Laravel 5.8 and 6.0 and works brilliantly.