### PR TITLE
.env file saving proccess abstractization

### DIFF
--- a/src/Controllers/EnvironmentController.php
+++ b/src/Controllers/EnvironmentController.php
@@ -69,7 +69,13 @@ class EnvironmentController extends Controller
      */
     public function saveClassic(Request $input, Redirector $redirect)
     {
-        $message = $this->EnvironmentManager->saveFileClassic($input);
+        $saveFile = $this->EnvironmentManager->saveFileClassic($input);
+
+        if ($saveFile) {
+            $message = trans('installer_messages.environment.success');
+        } else {
+            $message = trans('installer_messages.environment.errors');
+        }
 
         event(new EnvironmentSaved($input));
 
@@ -103,7 +109,13 @@ class EnvironmentController extends Controller
             ]);
         }
 
-        $results = $this->EnvironmentManager->saveFileWizard($request);
+        $saveFile = $this->EnvironmentManager->saveFileWizard($request);
+
+        if ($saveFile) {
+            $results = trans('installer_messages.environment.success');
+        } else {
+            $results = trans('installer_messages.environment.errors');
+        }
 
         event(new EnvironmentSaved($request));
 

--- a/src/Helpers/EnvironmentManager.php
+++ b/src/Helpers/EnvironmentManager.php
@@ -69,31 +69,27 @@ class EnvironmentManager
      * Save the edited content to the .env file.
      *
      * @param Request $input
-     * @return string
+     * @return bool
      */
     public function saveFileClassic(Request $input)
     {
-        $message = trans('installer_messages.environment.success');
-
         try {
             file_put_contents($this->envPath, $input->get('envConfig'));
         } catch (Exception $e) {
-            $message = trans('installer_messages.environment.errors');
+            return false;
         }
 
-        return $message;
+        return true;
     }
 
     /**
      * Save the form content to the .env file.
      *
      * @param Request $request
-     * @return string
+     * @return bool
      */
     public function saveFileWizard(Request $request)
     {
-        $results = trans('installer_messages.environment.success');
-
         $envFileData =
         'APP_NAME=\''.$request->app_name."'\n".
         'APP_ENV='.$request->environment."\n".
@@ -127,9 +123,9 @@ class EnvironmentManager
         try {
             file_put_contents($this->envPath, $envFileData);
         } catch (Exception $e) {
-            $results = trans('installer_messages.environment.errors');
+            return false;
         }
 
-        return $results;
+        return true;
     }
 }


### PR DESCRIPTION
Rather than returning a string (which can differ, based on the selected language), let's return a boolean instead.

We can then do the validation in the Controller based on the boolean value (true/false).

In its current state, if the .env file can't be written, the user still gets redirected to the database controller.

In the proposed form, we can potentially cancel the request, and return back with an error message, so the user doesn't lose his input values until the .env file permissions get updated.

The entire process will work exactly the same as before, just provides more flexibility for those with custom changes to it.