### PR TITLE
add javascript only when there is an error

### DIFF
--- a/src/Views/layouts/master.blade.php
+++ b/src/Views/layouts/master.blade.php
@@ -103,6 +103,7 @@
             </div>
         </div>
         @yield('scripts')
+        @if(session()->has('errors'))
         <script type="text/javascript">
             var x = document.getElementById('error_alert');
             var y = document.getElementById('close_alert');
@@ -110,5 +111,6 @@
                 x.style.display = "none";
             };
         </script>
+        @endif
     </body>
 </html>


### PR DESCRIPTION
Currently the javascript code fails to find the html elements with id 'error_alert' and 'close_alert' since these are only displayed if there is an error.
For this reason, an "if" control structure must be added so that the javascript code is only loaded when there is an error.